### PR TITLE
fix: conflict resolution of PR 11

### DIFF
--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
@@ -41,6 +41,7 @@
   {
    "fieldname": "customer",
    "fieldtype": "Link",
+   "in_standard_filter": 1,
    "label": "Customer",
    "options": "Customer"
   },
@@ -66,7 +67,6 @@
   {
    "fieldname": "from_time",
    "fieldtype": "Datetime",
-   "in_standard_filter": 1,
    "label": "From Time",
    "no_copy": 1,
    "reqd": 1
@@ -81,17 +81,14 @@
   {
    "fieldname": "to_time",
    "fieldtype": "Datetime",
-   "in_standard_filter": 1,
    "label": "To Time",
-   "no_copy": 1,
-   "read_only": 1
+   "no_copy": 1
   },
   {
    "fieldname": "actual_time",
    "fieldtype": "Duration",
    "label": "Actual Time",
-   "no_copy": 1,
-   "read_only": 1
+   "no_copy": 1
   },
   {
    "fieldname": "column_break_zgqwu",
@@ -109,15 +106,13 @@
    "fieldname": "activity_doctype",
    "fieldtype": "Link",
    "label": "Activity Doctype",
-   "options": "DocType",
-   "read_only": 1
+   "options": "DocType"
   },
   {
    "fieldname": "activity_docname",
    "fieldtype": "Dynamic Link",
    "label": "Activity Docname",
-   "options": "activity_doctype",
-   "read_only": 1
+   "options": "activity_doctype"
   },
   {
    "fieldname": "section_break_hqfwm",
@@ -138,8 +133,7 @@
    "fieldname": "result",
    "fieldtype": "Small Text",
    "label": "Result",
-   "no_copy": 1,
-   "read_only": 1
+   "no_copy": 1
   },
   {
    "fieldname": "amended_from",
@@ -151,6 +145,7 @@
    "read_only": 1
   },
   {
+   "default": "100%",
    "fieldname": "percent_billable",
    "fieldtype": "Select",
    "label": "Percent Billable",
@@ -166,7 +161,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-25 13:09:44.252370",
+ "modified": "2023-09-06 22:31:01.066101",
  "modified_by": "Administrator",
  "module": "Project Addon",
  "name": "Timesheet Record",


### PR DESCRIPTION
We have a merge conflict in #11 which forces us to update some code befor this can be merged.
![grafik](https://github.com/phamos-eu/Project-Addon/assets/22279621/e5a53e80-c131-473a-9422-26d83a18dca3)
As seen in the image we can not solve this by making changes to the PR itself.

Here ist a list of the changes that have been made:

JSON Changes:
    add standard filter: customer
    removed standard filter: customer
    removed standard filter: from_time, to_time
    remove read only: to_time, actual_time, activity_doctype, activity_doctype, result
    set default: percent_billable to 100%
    
@wojosc you can now safely close #11 and merge this PR.