### PR TITLE
fix: Empty project filter

### DIFF
--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.js
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.js
@@ -17,14 +17,14 @@ frappe.ui.form.on('Timesheet Record', {
 	},
 
 	project: function(frm) {
-		//apply filter to task field on project field selected
+		//Filter task based on project if project is selected first
 		frm.set_query("task", () => {
+			let filters = {};
+			if (frm.doc.project) filters["project"] = frm.doc.project;
 			return {
-				filters: [
-						["Task", "project", "=", frm.doc.project]
-					]
-				}
-			})
+				filters: filters
+			}
+		});
 	},
 	task: function(frm) {
 		//set project if task is clicked first


### PR DESCRIPTION
Problem: When a Project field is left blank, the task link field gets filtered on empty project filter.

Solution: Check if Project has a value before applying filter on task