### PR TITLE
feat: is_billable and billing_hours field set #22

### DIFF
--- a/project_addon/patches.txt
+++ b/project_addon/patches.txt
@@ -1,0 +1,1 @@
+project_addon.patches.v14_0.update_timesheet_record_percent_billable_field_options #1

--- a/project_addon/patches/v14_0/update_timesheet_record_percent_billable_field_options.py
+++ b/project_addon/patches/v14_0/update_timesheet_record_percent_billable_field_options.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
+# Copyright (c) 2023, phamos GmbH and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/project_addon/patches/v14_0/update_timesheet_record_percent_billable_field_options.py
+++ b/project_addon/patches/v14_0/update_timesheet_record_percent_billable_field_options.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	options_map = {'0%': '0', '25%': '25', '50%': '50', '75%': '75', '100%': '100'}
+	table = frappe.qb.DocType("Timesheet Record")
+	records = frappe.qb.from_(table).select(table.name, table.percent_billable).run(as_dict=True)
+	for d in records:
+		if options_map.get(d.get('percent_billable')):
+			frappe.qb.update(table).set('percent_billable', options_map.get(d.get('percent_billable'))).where(
+				table.name == d.get('name')
+			).run()

--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
@@ -145,11 +145,11 @@
    "read_only": 1
   },
   {
-   "default": "100%",
+   "default": "100",
    "fieldname": "percent_billable",
    "fieldtype": "Select",
    "label": "Percent Billable",
-   "options": "0%\n25%\n50%\n75%\n100%"
+   "options": "0\n25\n50\n75\n100"
   },
   {
    "fieldname": "employee",
@@ -161,7 +161,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-09-06 22:31:01.066101",
+ "modified": "2023-10-13 13:29:20.177980",
  "modified_by": "Administrator",
  "module": "Project Addon",
  "name": "Timesheet Record",

--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.py
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.py
@@ -43,15 +43,24 @@ class TimesheetRecord(Document):
 		timesheet.customer = self.customer
 		timesheet.note = description
 
+		is_billable = False
+		perc_billable_factor = 0
+		if self.percent_billable and self.percent_billable != '0%':
+			is_billable = True
+			perc_billable_factor = float(self.percent_billable.strip('%')) / 100
+
+		hours = round(float(self.actual_time) / 3600, 6)
+		billing_hours = hours * perc_billable_factor if is_billable and perc_billable_factor else 0
 		timesheet.append(
 			"time_logs",
 			{
-				"billable": 1 if self.percent_billable else 0,
+				"is_billable": is_billable,
+				"billing_hours": billing_hours,
 				"activity_type": self.activity_type,
 				"from_time": self.from_time,
 				"to_time": self.to_time,
 				"expected_hours": round(float(self.expected_time) / 3600, 6),
-				"hours": round(float(self.actual_time) / 3600, 6),
+				"hours": hours,
 				"description": description,
 				"project": self.project,
 				"task": self.task


### PR DESCRIPTION
Problem: When submitting 'Timesheet Record' Entry, the posted entry of 'Timesheet' should have is_billable checked and billing_hours set is set to factor of percent_billable * hours spent on 'Timesheet Record'

Solution: Applied above conditional calculation in  create_timesheet in 'Timesheet Record' controller 

Demo:
![Peek 2023-10-11 19-13](https://github.com/phamos-eu/Project-Addon/assets/25414115/a2d25dc3-f2f4-4bd5-ab4e-e1097bfd63d8)

Timesheet Record:
![image](https://github.com/phamos-eu/Project-Addon/assets/25414115/3a12899e-834b-403d-b175-5e2503b3ee30)

'Timesheet' Timelogs
![image](https://github.com/phamos-eu/Project-Addon/assets/25414115/70443b15-7755-4351-9d57-ec474d0de01c)
