### PR TITLE
fix: Refresh after Complete #13

### DIFF
--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.js
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.js
@@ -51,16 +51,17 @@ frappe.ui.form.on('Timesheet Record', {
 			},
 		], (values) => {
 			frappe.call({
-				method:"project_addon.project_addon.doctype.timesheet_record.timesheet_record.mark_complete",
+				method:"project_addon.project_addon.doctype.timesheet_record.timesheet_record.mark_complete_validate",
 				args: {
 					"doc": frm.doc.name,
 					"result": values.result,
 					"to_time": values.to_time
 				},
 				callback: function(r) {
-					if(!r.exc){
-						frm.refresh_field('to_time');
-						frm.refresh_field('result');
+					if(!r.exc && r.message.status === true){
+						frm.set_value("to_time", values.to_time);
+						frm.set_value("result", values.result);
+						frm.save();
 					}
 				}
 			});

--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.py
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.py
@@ -76,10 +76,10 @@ class TimesheetRecord(Document):
 
 
 @frappe.whitelist()
-def mark_complete(doc, result, to_time):
+def mark_complete_validate(doc, result, to_time):
 	doc = frappe.get_doc("Timesheet Record", doc)
 	doc.result = result
 	doc.to_time = to_time
 
 	doc.validate()
-	doc.save()
+	return {'status': True}


### PR DESCRIPTION
Problem: When finishing the "Timesheet Record" via the "Mark Complete" button the DocType is not refreshed/reloaded. so, to show the new data added one has to update manually.

Solution: On clicking "Mark Complete" button it will set values (to_time and result) in "Timesheet Record" for validating, if validated successfully from server then it will return status as True and set fields values from prompt popup and save the form.   

Demo:
![Peek 2023-10-11 22-52-30-mins](https://github.com/phamos-eu/Project-Addon/assets/25414115/8ae9037a-9c22-4c94-9050-35d693c495e0)
