### PR TITLE
fix: result field readonly

### DIFF
--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
@@ -125,7 +125,6 @@
    "fieldtype": "Small Text",
    "label": "Goal",
    "no_copy": 1,
-   "read_only": 1,
    "reqd": 1
   },
   {
@@ -136,7 +135,8 @@
    "fieldname": "result",
    "fieldtype": "Small Text",
    "label": "Result",
-   "no_copy": 1
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "amended_from",
@@ -164,7 +164,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-18 15:31:20.376162",
+ "modified": "2023-10-18 15:33:37.784812",
  "modified_by": "Administrator",
  "module": "Project Addon",
  "name": "Timesheet Record",

--- a/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
+++ b/project_addon/project_addon/doctype/timesheet_record/timesheet_record.json
@@ -125,6 +125,7 @@
    "fieldtype": "Small Text",
    "label": "Goal",
    "no_copy": 1,
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -163,10 +164,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-13 13:29:20.177980",
+ "modified": "2023-10-18 15:31:20.376162",
  "modified_by": "Administrator",
  "module": "Project Addon",
  "name": "Timesheet Record",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -185,5 +187,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
Issue (#27 ): The field result does not need to be visible on creation. Just like other fields it can be shown once it has been populated via the "Mark Complete" function 



Resolved
![image](https://github.com/phamos-eu/Project-Addon/assets/25414115/e8004df4-77d8-4f80-81f8-b7a7b14f8f9d)
